### PR TITLE
fix convert_bcsam_file function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'g2gtools'
-version = '2.0.0'
+version = '2.1.0'
 description = 'A suite of tools for the reconstruction of personal diploid genomes and better coordinate conversion'
 authors = [
     {name = 'KB Choi'},


### PR DESCRIPTION
`bcsam.py` required additional changes to account for updates from py2 to py3 and due to the increment in pysam version to 0.20.0. 

- `pysam` changed the API term: `cigar` to `cigartuples`. Calls were updated to account for this change. 
- Mapping of contig names to header positions was off, and required correction.
- `g2g.get_logger` was used in several places when `g2g_utils.get_logger` was intended. 