### PR TITLE
Implement reverse lookup for bedfiles

### DIFF
--- a/src/g2gtools/bed.py
+++ b/src/g2gtools/bed.py
@@ -241,8 +241,8 @@ def convert_bed_file(
             for lr in left_right:
                 if reverse:
                     source_seq_id = f'{record.chrom}'
-                    assert f'{record.chrom[-2:]}' in lr
-                    target_seq_id = f'{record.chrom[:-2]}'
+                    assert f'{record.chrom[-len(lr):]}' in lr
+                    target_seq_id = f'{record.chrom[:-len(lr)]}'
                 else:
                     source_seq_id = f'{record.chrom}'
                     target_seq_id = f'{record.chrom}{lr}'


### PR DESCRIPTION
I'm working with a bedfile that I want to convert back to reference coordinates, but the bed.py (and maybe other file formats?) assumes --reverse is true.

I've implemented a fix for bedfiles, since it's my current use case, but it might be something that is more generalizable.

Logic behind the change:
If forward:
  - Each record outputs two records in converted file, requiring [lr] loop
  - current seqID is always chrom, and target is always chrom+_L/R

But if reverse:
  - Each record outputs only *one* record in converted file. LR loop will cause duplicate records to be made.
  - Current seqID already has L/R suffix. The target seq ID is not chrom plus _L/R suffix, it's record_seq_id minus _L/R suffix.

This commit:
  - Separates the source and target id into two separate variables defined at the beginning of the record loop
  - Determines source and target id appropriately when forward or reverse
  - If reverse, breaks out of LR loop after first go-around. Instead of refactoring the loop to handle the reverse case in a special manner, and only implement the loop in the forward case, this somewhat hacky solution allows for the current code structure to be minimally changed.
